### PR TITLE
Throw on non-root uid

### DIFF
--- a/st2auth_pam_backend/pam_backend.py
+++ b/st2auth_pam_backend/pam_backend.py
@@ -43,10 +43,13 @@ class PAMAuthenticationBackend(object):
     pam_ffi is implemented using ctypes, so no compilation is necessary.
     """
 
-    def __init__(self):
-        uid = os.geteuid()
-        if uid != 0:
-            raise ValueError(NON_ROTT_ERROR_MSG)
+    def __init__(self, check_for_root=True):
+        """
+        :param check_for_root: True to check that the current process is running as root (uid 0).
+        :type check_for_root: ``bool``
+        """
+        if check_for_root:
+            self._verify_running_as_root()
 
     def authenticate(self, username, password):
         try:
@@ -59,3 +62,9 @@ class PAMAuthenticationBackend(object):
         except:
             LOG.exception('Unable to PAM authenticate user "%s".', username)
             raise
+
+    def _verify_running_as_root(self):
+        uid = os.geteuid()
+
+        if uid != 0:
+            raise ValueError(NON_ROTT_ERROR_MSG)

--- a/st2auth_pam_backend/pam_backend.py
+++ b/st2auth_pam_backend/pam_backend.py
@@ -15,6 +15,7 @@
 
 from __future__ import absolute_import
 
+import os
 import logging
 
 __all__ = [
@@ -24,6 +25,11 @@ __all__ = [
 from st2auth_pam_backend.pam_ffi import auth as pam_auth
 
 LOG = logging.getLogger(__name__)
+
+PAM_DOCS_LINK = 'https://docs.stackstorm.com/install/deb.html#configure-authentication'
+NON_ROTT_ERROR_MSG = ('When using pam backend, st2auth process needs to run as "root" so it can '
+                      'read /etc/shadow file. For more details please see %s' %
+                      (PAM_DOCS_LINK))
 
 
 class PAMAuthenticationBackend(object):
@@ -38,7 +44,9 @@ class PAMAuthenticationBackend(object):
     """
 
     def __init__(self):
-        pass
+        uid = os.geteuid()
+        if uid != 0:
+            raise ValueError(NON_ROTT_ERROR_MSG)
 
     def authenticate(self, username, password):
         try:

--- a/st2auth_pam_backend/pam_backend.py
+++ b/st2auth_pam_backend/pam_backend.py
@@ -28,7 +28,7 @@ LOG = logging.getLogger(__name__)
 
 PAM_DOCS_LINK = 'https://docs.stackstorm.com/install/deb.html#configure-authentication'
 NON_ROTT_ERROR_MSG = ('When using pam backend, st2auth process needs to run as "root" so it can '
-                      'read /etc/shadow file. For more details please see %s' %
+                      'read /etc/shadow file. For more details, please see %s' %
                       (PAM_DOCS_LINK))
 
 

--- a/st2auth_pam_backend/pam_backend.py
+++ b/st2auth_pam_backend/pam_backend.py
@@ -27,7 +27,7 @@ from st2auth_pam_backend.pam_ffi import auth as pam_auth
 LOG = logging.getLogger(__name__)
 
 PAM_DOCS_LINK = 'https://docs.stackstorm.com/install/deb.html#configure-authentication'
-NON_ROTT_ERROR_MSG = ('When using pam backend, st2auth process needs to run as "root" so it can '
+NON_ROOT_ERROR_MSG = ('When using pam backend, st2auth process needs to run as "root" so it can '
                       'read /etc/shadow file. For more details, please see %s' %
                       (PAM_DOCS_LINK))
 
@@ -67,4 +67,4 @@ class PAMAuthenticationBackend(object):
         uid = os.geteuid()
 
         if uid != 0:
-            raise ValueError(NON_ROTT_ERROR_MSG)
+            raise ValueError(NON_ROOT_ERROR_MSG)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 unittest2
+mock
 pep8>=1.6.0,<1.7
 flake8>=2.3.0,<2.4
 pylint>=1.4.3,<1.5

--- a/tests/integration/test_authenticate.py
+++ b/tests/integration/test_authenticate.py
@@ -29,6 +29,10 @@ class PAMBackendAuthenticationTest(unittest2.TestCase):
         self.assertRaisesRegexp(ValueError, expected_msg,
                                 pam_backend.PAMAuthenticationBackend)
 
+        # non root, but check for root is disabled
+        mock_get_euid.return_value = 100
+        pam_backend.PAMAuthenticationBackend(check_for_root=False)
+
         # root
         mock_get_euid.return_value = 0
         pam_backend.PAMAuthenticationBackend()


### PR DESCRIPTION
This pull request updates the code if the st2auth process is not running as root (effective uid != 0) when using PAM auth backend.

We have some docs on this requirement now, but users are still encountering this issue so we should make code more user-friendly and point users to the right direction.