### PR TITLE
Adding parameter to choose which pam to use

### DIFF
--- a/st2auth_pam_backend/pam_backend.py
+++ b/st2auth_pam_backend/pam_backend.py
@@ -43,17 +43,20 @@ class PAMAuthenticationBackend(object):
     pam_ffi is implemented using ctypes, so no compilation is necessary.
     """
 
-    def __init__(self, check_for_root=True):
+    def __init__(self, check_for_root=True, service='login'):
         """
         :param check_for_root: True to check that the current process is running as root (uid 0).
         :type check_for_root: ``bool``
+        :param service: PAM service to authenticate against
+        :type service: ``string``
         """
         if check_for_root:
             self._verify_running_as_root()
+        self.pam_service = service
 
     def authenticate(self, username, password):
         try:
-            ret = pam_auth(username, password)
+            ret = pam_auth(username, password, service=self.pam_service)
             if ret:
                 LOG.info('Successfully authenticated user "%s".', username)
             else:


### PR DESCRIPTION
Hi,
Here is a small patch which enables us to choose which pam to authenticate against. You could imagine adding 'backend_kwargs = {"service": "st2"}' to your st2.conf and thus st2auth will use the "st2" pam file for authentication. 
This is handy when you have to limit users who can authenticate (using pam_access for example)

Cheers,

Romain F.