### PR TITLE
Added note about root user not being able to authenticate

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ api_url = https://myhost.examples.com:9101
 debug = False
 ```
 
+### Limitations
+
+The python implementation of PAM does not allow authentication as the `root` user.
+When utilizing this backend, you will need to authenticate as a non-`root` user.
+
+
 ## Copyright, License, and Contributors Agreement
 
 Copyright 2015 StackStorm, Inc.


### PR DESCRIPTION
When testing out this backend it threw me for a loop when i was getting auth failures. Turns out i was trying to auth as root and that's not supported.

Added some documentation here in case others run into the same problem.