### PR TITLE
Python3 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - 2.7
+  - 3.6
 
 # Used old infrastructure, needed for integration tests:
 # http://docs.travis-ci.com/user/workers/standard-infrastructure/
@@ -18,8 +18,8 @@ cache:
     - $HOME/.cache/pip/
 
 install:
-  - sudo -H pip install tox
-  - sudo -H pip install --upgrade pip
+  - pip install --upgrade pip
+  - pip install tox
   - if [ ${TASK} = 'integration' ]; then sudo -E ./scripts/travis/prepare-integration.sh; fi
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - 3.6
+  - 3.8
 
 # Used old infrastructure, needed for integration tests:
 # http://docs.travis-ci.com/user/workers/standard-infrastructure/

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -9,8 +9,13 @@ fi
 if [ ${TASK} == 'checks' ]; then
   tox -e lint
 elif [ ${TASK} == 'integration' ]; then
+  set -x
   # If we need more python versions, add them here.
-  sudo bash -c "source /home/travis/virtualenv/python3.6/bin/activate && tox -e py27,py36"
+  if [ -d /home/travis/virtualenv/python3.8/bin ]; then
+    sudo bash -c "source /home/travis/virtualenv/python3.8/bin/activate && tox -e py38" || exit $?
+  else
+    sudo bash -c "source /home/travis/virtualenv/python3.6/bin/activate && tox -e py27,py36" || exit $?
+  fi
 else
   echo "Invalid task: ${TASK}"
   exit 2

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -9,7 +9,8 @@ fi
 if [ ${TASK} == 'checks' ]; then
   tox -e lint
 elif [ ${TASK} == 'integration' ]; then
-  sudo tox -e py27  # If we need more python versions, add them here.
+  # If we need more python versions, add them here.
+  sudo bash -c "source /home/travis/virtualenv/python3.6/bin/activate && tox -e py27,py36"
 else
   echo "Invalid task: ${TASK}"
   exit 2

--- a/st2auth_pam_backend/__init__.py
+++ b/st2auth_pam_backend/__init__.py
@@ -21,4 +21,4 @@ __all__ = [
     'PAMAuthenticationBackend'
 ]
 
-__version__ = '0.1.0'
+__version__ = '0.2.0'

--- a/st2auth_pam_backend/pam_ffi.py
+++ b/st2auth_pam_backend/pam_ffi.py
@@ -20,8 +20,9 @@ Implemented using ctypes, so no compilation is necessary.
 
 # Import Python Libs
 from __future__ import absolute_import
-from ctypes import CDLL, POINTER, Structure, CFUNCTYPE, cast, pointer, sizeof
+from ctypes import CDLL, POINTER, Structure, CFUNCTYPE, cast, pointer, sizeof, byref
 from ctypes import c_void_p, c_uint, c_char_p, c_char, c_int
+from ctypes import memmove
 from ctypes.util import find_library
 
 from six.moves import range  # pylint: disable=import-error,redefined-builtin
@@ -148,17 +149,23 @@ def authenticate(username, password, service='login'):
         '''
         # Create an array of n_messages response objects
         addr = CALLOC(n_messages, sizeof(PamResponse))
-        p_response[0] = cast(addr, POINTER(PamResponse))
+        response = cast(addr, POINTER(PamResponse))
+        p_response[0] = response
         for i in range(n_messages):
             if messages[i].contents.msg_style == PAM_PROMPT_ECHO_OFF:
-                pw_copy = STRDUP(str(password))
-                p_response.contents[i].resp = cast(pw_copy, c_char_p)
-                p_response.contents[i].resp_retcode = 0
+                dst = CALLOC(len(password)+1, sizeof(c_char))
+                memmove(dst, cpassword, len(password))
+                response[i].resp = dst
+                response[i].resp_retcode = 0
         return 0
 
+    username = username.encode('UTF-8')
+    password = password.encode('UTF-8')
+    service = service.encode('UTF-8')
+    cpassword = c_char_p(password)
     handle = PamHandle()
     conv = PamConv(my_conv, 0)
-    retval = PAM_START(service, username, pointer(conv), pointer(handle))
+    retval = PAM_START(service, username, byref(conv), byref(handle))
 
     if retval != 0:
         # TODO: This is not an authentication error, something

--- a/st2auth_pam_backend/pam_ffi.py
+++ b/st2auth_pam_backend/pam_ffi.py
@@ -20,7 +20,7 @@ Implemented using ctypes, so no compilation is necessary.
 
 # Import Python Libs
 from __future__ import absolute_import
-from ctypes import CDLL, POINTER, Structure, CFUNCTYPE, cast, pointer, sizeof, byref
+from ctypes import CDLL, POINTER, Structure, CFUNCTYPE, cast, sizeof, byref
 from ctypes import c_void_p, c_uint, c_char_p, c_char, c_int
 from ctypes import memmove
 from ctypes.util import find_library
@@ -153,7 +153,7 @@ def authenticate(username, password, service='login'):
         p_response[0] = response
         for i in range(n_messages):
             if messages[i].contents.msg_style == PAM_PROMPT_ECHO_OFF:
-                dst = CALLOC(len(password)+1, sizeof(c_char))
+                dst = CALLOC(len(password) + 1, sizeof(c_char))
                 memmove(dst, cpassword, len(password))
                 response[i].resp = dst
                 response[i].resp_retcode = 0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,8 @@
-mock==3.0.5
+mock==3.0.5 ; python_version == '2.7'
+mock==4.0.3 ; python_version >= '3.6'
 nose>=1.3.7
 pep8==1.7.1
-pylint==1.9.4
+pylint<2 ; python_version == '2.7'
+pylint==2.8.2 ; python_version >= '3.6'
 st2flake8==0.1.0
 unittest2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,lint
+envlist = py27,py36,py38,lint
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
@@ -11,6 +11,10 @@ commands = python setup.py test
 
 [testenv:py36]
 basepython = python3.6
+commands = python setup.py test
+
+[testenv:py38]
+basepython = python3.8
 commands = python setup.py test
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = py27,lint
-#envlist = py27,py36,lint
+envlist = py27,py36,lint
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt
@@ -10,9 +9,9 @@ deps = -r{toxinidir}/requirements.txt
 basepython = python2.7
 commands = python setup.py test
 
-#[testenv:py36]
-#basepython = python3.6
-#commands = python setup.py test
+[testenv:py36]
+basepython = python3.6
+commands = python setup.py test
 
 [testenv:lint]
 commands = flake8 --config ./lint-configs/python/.flake8 st2auth_pam_backend/


### PR DESCRIPTION
This includes #17 to fix python3 TypeError ctype exceptions.

This changes the test config so that it starts testing with python3 and python2 to show that functionality has not changed. A separate PR can remove python2 support.

Bumps version from 0.1.0 to 0.2.0

Closes #17 